### PR TITLE
6 private init for nmea structs ggadata and rmcdata

### DIFF
--- a/Sources/NMEAParser/Sentences/GGA/GGAData.swift
+++ b/Sources/NMEAParser/Sentences/GGA/GGAData.swift
@@ -52,4 +52,31 @@ public struct GGAData {
         case glGGA = "$GLGGA" // GGA sentence from GLONASS
         case gaGGA = "$GAGGA" // GGA sentence from GALILEO
     }
+    
+    // MARK: - Init
+    /// The GGA sentence (Global Positioning System Fix Data) provides essential fix data from a GNSS receiver.
+    /// It contains the following information:
+    /// - Parameters:
+    ///   - time: The time the fix was taken, in hhmmss.ss format.
+    ///   - latitude: The latitude in degrees and minutes (converted to decimal degrees).
+    ///   - longitude: The longitude in degrees and minutes (converted to decimal degrees).
+    ///   - fixType: The quality of the fix (e.g., autonomous, gps, dgps, rtkFloat, etc.).
+    ///   - satellitesUsed: The number of satellites used to compute the fix.
+    ///   - hdop: Horizontal Dilution of Precision, which indicates the quality of the GPS signal.
+    ///   - altitude: The altitude (in meters) above mean sea level.
+    public init(time: String?,
+                latitude: CLLocationDegrees,
+                longitude: CLLocationDegrees,
+                fixType: GGAFixType,
+                satellitesUsed: UInt8,
+                hdop: Double,
+                altitude: Double) {
+        self.time = time
+        self.latitude = latitude
+        self.longitude = longitude
+        self.fixType = fixType
+        self.satellitesUsed = satellitesUsed
+        self.hdop = hdop
+        self.altitude = altitude
+    }
 }

--- a/Sources/NMEAParser/Sentences/RMC/RMCData.swift
+++ b/Sources/NMEAParser/Sentences/RMC/RMCData.swift
@@ -61,4 +61,40 @@ public struct RMCData {
         case glRMC = "$GLRMC" // RMC sentence from GLONASS
         case gaRMC = "$GARMC" // RMC sentence from GALILEO
     }
+    
+    // MARK: - Init
+    /// The RMC sentence (Recommended Minimum Navigation Information) provides vital navigation data.
+    /// It contains the following information:
+    /// - Parameters:
+    ///   - time: The time the fix was taken, in hhmmss.ss format.
+    ///   - status: The validity status of the fix ('A' for active/valid, 'V' for void).
+    ///   - latitude: The latitude in degrees and minutes (converted to decimal degrees).
+    ///   - longitude: The longitude in degrees and minutes (converted to decimal degrees).
+    ///   - speedOverGround: The speed of the receiver over the ground, in knots.
+    ///   - courseOverGround: The true course over ground, in degrees.
+    ///   - date: The date of the fix, in ddmmyy format.
+    ///   - magneticVariation: The variation in the magnetic field, in degrees.
+    ///   - magneticVariationDirection: The direction of the magnetic variation ('E' for east, 'W' for west).
+    ///   - mode: An optional mode indicator providing additional navigational information.
+    public init(time: String?,
+                status: String?,
+                latitude: CLLocationDegrees,
+                longitude: CLLocationDegrees,
+                speedOverGround: Double?,
+                courseOverGround: Double?,
+                date: String?,
+                magneticVariation: Double?,
+                magneticVariationDirection: String?,
+                mode: String?) {
+        self.time = time
+        self.status = status
+        self.latitude = latitude
+        self.longitude = longitude
+        self.speedOverGround = speedOverGround
+        self.courseOverGround = courseOverGround
+        self.date = date
+        self.magneticVariation = magneticVariation
+        self.magneticVariationDirection = magneticVariationDirection
+        self.mode = mode
+    }
 }


### PR DESCRIPTION
This pull request introduces new initializers for the `GGAData` and `RMCData` structs in the NMEAParser library. These initializers provide a more detailed and structured way to create instances of these structs, including comprehensive documentation for each parameter.

New initializers:

* [`Sources/NMEAParser/Sentences/GGA/GGAData.swift`](diffhunk://#diff-ad7ae5e967cd34368bbdc8617d562357923f6fa74980c9d14956da204414f9eaR55-R81): Added an initializer to the `GGAData` struct, which includes detailed parameter descriptions for time, latitude, longitude, fixType, satellitesUsed, hdop, and altitude.
* [`Sources/NMEAParser/Sentences/RMC/RMCData.swift`](diffhunk://#diff-dcf181ff35b8e357ed85db7adcde61b10c1ccce12e6a0d523df609117773166fR64-R99): Added an initializer to the `RMCData` struct, which includes detailed parameter descriptions for time, status, latitude, longitude, speedOverGround, courseOverGround, date, magneticVariation, magneticVariationDirection, and mode.