### PR TITLE
8 chore: add codable to ggafixtype

### DIFF
--- a/Sources/NMEAParser/Sentences/GGA/FixType/GGAFixType.swift
+++ b/Sources/NMEAParser/Sentences/GGA/FixType/GGAFixType.swift
@@ -5,7 +5,8 @@
 //  Created by Sindre on 12/02/2025.
 //
 
-public enum GGAFixType: UInt8 {
+public enum GGAFixType: UInt8, Codable {
+    
     // MARK: - Cases
     
     /// Invalid, no position available.


### PR DESCRIPTION
This pull request includes a small but important change to the `GGAFixType` enum in the `Sources/NMEAParser/Sentences/GGA/FixType/GGAFixType.swift` file. The change makes the enum conform to the `Codable` protocol, which will allow instances of `GGAFixType` to be easily encoded and decoded.

* [`Sources/NMEAParser/Sentences/GGA/FixType/GGAFixType.swift`](diffhunk://#diff-566c99bd9f54a164dd95d92e458886d43023fb1e5de8bd46895d2b8fae971ce9L8-R9): Updated `GGAFixType` enum to conform to the `Codable` protocol.